### PR TITLE
Fix square button compile error

### DIFF
--- a/controller.ino
+++ b/controller.ino
@@ -111,7 +111,8 @@ void handleDpad() {
 void handleSquareMotor() {
   if (!ps4Controller) return;
 
-  bool sq = ps4Controller->square();
+  // "Square" des PS4-Controllers entspricht BUTTON_X
+  bool sq = ps4Controller->x();
 
   if (sq && !prevSquare) {
     if (extraMotorRunning) {


### PR DESCRIPTION
## Summary
- fix build break caused by missing `square()` method

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684fc680cc5883279ac6a0a458ae4700